### PR TITLE
fix(workflow): default AIRFLOW_ENDPOINT so DAG triggering cannot silently break

### DIFF
--- a/app/routers/workflow.py
+++ b/app/routers/workflow.py
@@ -25,7 +25,7 @@ router = APIRouter()
 
 # Airflow configs
 AIRFLOW_ENABLED = os.getenv("AIRFLOW_ENABLED", "false").lower() == "true"
-AIRFLOW_ENDPOINT = os.getenv("AIRFLOW_ENDPOINT")
+AIRFLOW_ENDPOINT = os.getenv("AIRFLOW_ENDPOINT", "http://airflow-apiserver:8080/airflow")
 AIRFLOW_USERNAME = os.getenv("AIRFLOW_USERNAME", "admin")
 AIRFLOW_PASSWORD = os.getenv("AIRFLOW_PASSWORD", "admin")
 


### PR DESCRIPTION
## What

Give `AIRFLOW_ENDPOINT` an in-code default in `app/routers/workflow.py`:

```python
AIRFLOW_ENDPOINT = os.getenv("AIRFLOW_ENDPOINT", "http://airflow-apiserver:8080/airflow")
```

## Why

After the preprocessor was merged into the API (#236), `app/routers/workflow.py` is what triggers the child `workflow_{seek_id}` DAG runs. It read the endpoint with a bare `os.getenv("AIRFLOW_ENDPOINT")` and **no fallback**, so if the variable is ever absent from the environment it resolves to `None` and every request URL silently becomes:

- `None/auth/token`
- `None/api/v2/dags/{dag_id}/dagRuns`

The platform `docker-compose.yml` currently supplies the value via `${AIRFLOW_ENDPOINT:-http://airflow-apiserver:8080/airflow}`, so today it only bites when the API is run outside that compose (or if a future edit drops the compose default). The trigger path should not depend on the compose being correct.

## Change

Default to the same internal endpoint the compose uses — `http://airflow-apiserver:8080/airflow` — which matches the base path the apiserver serves under (`AIRFLOW__API__BASE_URL`, `AIRFLOW__CORE__EXECUTION_API_SERVER_URL`). Consistent with how `AIRFLOW_USERNAME` / `AIRFLOW_PASSWORD` already default in the same block.

No behavioural change when `AIRFLOW_ENDPOINT` is set (the normal deployed case); this only adds a safe fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
